### PR TITLE
Update testing matrix for Wagtail 5.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,14 +14,18 @@ jobs:
       matrix:
         python: ["3.11", "3.10", "3.9", "3.8"]
         django: ["django>=3.2,<3.3", "django>=4.1,<4.2", "django>=4.2,<4.3"]
-        wagtail: ["wagtail>=4.1,<4.2", "wagtail>=4.2,<5.0"]
+        wagtail: ["wagtail>=4.1,<4.2", "wagtail>=4.2,<5.0", "wagtail>=5.0,<5.1"]
         exclude:
           - python: "3.11"
             django: django>=3.2,<3.3
+          - django: django>=4.2,<4.3
+            wagtail: wagtail>=4.1,<4.2
+          - django: django>=4.2,<4.3
+            wagtail: wagtail>=4.2,<5.0
         include:
           - python: "3.11"
             django: django>=4.2,<4.3
-            wagtail: wagtail>=5.0,<5.1
+            wagtail: wagtail>=5.1,<5.2
             latest: true
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,19 +14,12 @@ jobs:
       matrix:
         python: ["3.11", "3.10", "3.9", "3.8"]
         django: ["django>=3.2,<3.3", "django>=4.1,<4.2", "django>=4.2,<4.3"]
-        wagtail: ["wagtail>=4.1,<4.2", "wagtail>=4.2,<5.0", "wagtail>=5.0,<5.1"]
+        wagtail: ["wagtail>=4.1,<4.2", "wagtail>=5.1,<5.2", "wagtail>=5.2,<5.3"]
         exclude:
           - python: "3.11"
             django: django>=3.2,<3.3
           - django: django>=4.2,<4.3
             wagtail: wagtail>=4.1,<4.2
-          - django: django>=4.2,<4.3
-            wagtail: wagtail>=4.2,<5.0
-        include:
-          - python: "3.11"
-            django: django>=4.2,<4.3
-            wagtail: wagtail>=5.1,<5.2
-            latest: true
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update for wagtail 5.1
+
 ## 2.0.1 (2023-07-27)
 
 - Improve developer documentation


### PR DESCRIPTION
## [Wagtail 5.2 release notes](https://docs.wagtail.org/en/stable/releases/5.2.html)

## Includes PR: https://github.com/torchbox/wagtail-jotform/pull/29

Changes:
- Update test matrix to include Wagtail 5.2