### PR TITLE
Add testing for Wagtail 6.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,16 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.12", "3.11", "3.10", "3.9", "3.8"]
+        python: ["3.12", "3.11", "3.10", "3.9"]
         django: ["django>=4.2,<4.3", "django>=5.0,<5.1"]
         wagtail: ["wagtail>=5.2,<5.3", "wagtail>=6.0,<6.1", "wagtail>=6.1,<6.2"]
         exclude:
-          - python: "3.8"
-            django: "django>=5.0,<5.1"
           - python: "3.9"
             django: "django>=5.0,<5.1"
           - python: "3.12"
             django: "django>=4.2,<4.3"
+        include:
+          - python: "3.12"
+            django: "django>=5.1,<5.2"
+            wagtail: "wagtail>=6.3,<6.4"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
This pull request includes updates to the CI configuration and the `setup.py` file, primarily focusing on the supported Python versions.

Updates to CI configuration:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L15-R26): Removed Python 3.8 from the matrix and added a new combination for Python 3.12 with Django 5.1 and Wagtail 6.3.

Updates to `setup.py`:

* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L33): Removed support for Python 3.8.