### PR TITLE
Wagtail v7.0 maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,35 +13,30 @@ jobs:
     strategy:
       matrix:
         python: ["3.13", "3.12", "3.11", "3.10", "3.9"]
-        django: ["django>=4.2,<4.3", "django>=5.0,<5.1", "django>=5.1,<5.2"]
+        django: ["django>=4.2,<4.3", "django>=5.1,<5.2", "django>=5.2,<5.3"]
         wagtail:
           [
             "wagtail>=5.2,<5.3",
-            "wagtail>=6.0,<6.1",
-            "wagtail>=6.1,<6.2",
-            "wagtail>=6.2,<6.3",
             "wagtail>=6.3,<6.4",
+            "wagtail>=6.4,<6.5",
+            "wagtail>=7.0,<7.1",
           ]
         exclude:
-          - python: "3.9"
-            django: "django>=5.0,<5.1"
-          - python: "3.9"
-            django: "django>=5.1,<5.2"
+          # Python 3.13 is not compatible with Django 4.2
           - python: "3.13"
             django: "django>=4.2,<4.3"
-          - python: "3.13"
-            django: "django>=5.0,<5.1"
-          - python: "3.13"
+
+          # Django 5.1/5.2 with Wagtail 5.2 combinations are excluded for all Python versions
+          - django: "django>=5.1,<5.2"
             wagtail: "wagtail>=5.2,<5.3"
-          - python: "3.13"
-            wagtail: "wagtail>=6.0,<6.1"
-          - python: "3.13"
-            wagtail: "wagtail>=6.1,<6.2"
-          - python: "3.13"
+          - django: "django>=5.2,<5.3"
+            wagtail: "wagtail>=5.2,<5.3"
+
         include:
           - python: "3.13"
-            django: "django>=5.1,<5.2"
-            wagtail: "wagtail>=6.4,<6.5"
+            django: "django>=5.2,<5.3"
+            wagtail: "wagtail>=7.0,<7.1"
+            latest: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add support/testing for Wagtail 6.1, 6.2, 6.3 and 6.4
-- Add support/testing for Django 5.0 & 5.1
+- Add support/testing for Wagtail 6.3, 6.4 and 7.0
+- Add support/testing for Django 5.1 and 5.2
 - Drop testing for Django < 4.2
-- Drop support for Python < 3.8
-- Add support for Python 3.13
+- Drop support for Python < 3.9
+- Add support for Python 3.9, 3.10, 3.11, 3.12 and 3.13
+- Add tox configuration for local testing
 
 ## 2.2.0 (2024-03-07)
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
-testing_extras = ["coverage>=6.4.1", "tox-poetry>=0.4.1"]
+testing_extras = ["coverage>=6.4.1", "tox>=4.11.0"]
 development_extras = ["black", "isort", "flake8", "pre-commit"]
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,33 @@
+[tox]
+skipsdist = True
+usedevelop = True
+skip_missing_interpreters = True
+
+envlist =
+    python{39,310,311,312}-django{42}-wagtail{52,63,64,70}
+    python{39,310,311,312}-django{51,52}-wagtail{63,64,70}
+    python313-django{51,52}-wagtail{63,64,70}
+
+[testenv]
+install_command = pip install -e ".[testing]" -U {opts} {packages}
+
+commands =
+    coverage run ./runtests.py
+    coverage report
+
+deps =
+    django42: Django>=4.2,<4.3
+    django51: Django>=5.1,<5.2
+    django52: Django>=5.2,<5.3
+    wagtail52: wagtail>=5.2,<5.3
+    wagtail63: wagtail>=6.3,<6.4
+    wagtail64: wagtail>=6.4,<6.5
+    wagtail70: wagtail>=7.0,<7.1
+    coverage
+
+basepython =
+    py39: python3.9
+    py310: python3.10
+    py311: python3.11
+    py312: python3.12
+    py313: python3.13


### PR DESCRIPTION
This pull request updates the project's testing matrix, dependencies, and configuration files.

### Testing matrix updates:

* Updated the GitHub Actions workflow (`.github/workflows/test.yml`) to include Django 5.2 and Wagtail 7.0 in the testing matrix, while removing older Wagtail versions (6.0–6.2). Excluded incompatible combinations, such as Python 3.13 with Django 4.2 and certain Wagtail versions.

### Dependency and configuration updates:

* Updated the `CHANGELOG.md` to reflect support for Django 5.1/5.2, Wagtail 7.0, and Python 3.9–3.13, while dropping support for Python < 3.9. Added a note about the new `tox` configuration.
* Replaced `tox-poetry` with `tox` in the `setup.py` file to align with the testing setup.
* Added a `tox.ini` file to define environments for local testing with combinations of Python (3.9–3.13), Django (4.2–5.2), and Wagtail (5.2–7.0). 