### PR TITLE
Update for Wagtail 7.1 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ setup(
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
         "Framework :: Wagtail",
-        "Framework :: Wagtail :: 5",
         "Framework :: Wagtail :: 6",
+        "Framework :: Wagtail :: 7",
     ],
     extras_require={"testing": testing_extras, "development": development_extras},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,9 @@ usedevelop = True
 skip_missing_interpreters = True
 
 envlist =
-    python{39,310,311,312}-django{42}-wagtail{52,63,64,70}
-    python{39,310,311,312}-django{51,52}-wagtail{63,64,70}
-    python313-django{51,52}-wagtail{63,64,70}
+    python{39,310,311,312}-django{42}-wagtail{63,70,71}
+    python{39,310,311,312}-django{51,52}-wagtail{63,70,71}
+    python313-django{51,52}-wagtail{63,70,71}
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -19,10 +19,9 @@ deps =
     django42: Django>=4.2,<4.3
     django51: Django>=5.1,<5.2
     django52: Django>=5.2,<5.3
-    wagtail52: wagtail>=5.2,<5.3
     wagtail63: wagtail>=6.3,<6.4
-    wagtail64: wagtail>=6.4,<6.5
     wagtail70: wagtail>=7.0,<7.1
+    wagtail71: wagtail>=7.1,<7.2
     coverage
 
 basepython =


### PR DESCRIPTION
Update to support Wagtail 7.1, changes to tox matrix and PyPi classifiers

### Changes
- tox.ini
    - Added Wagtail 7.1, removed Wagtail 5.2 and 6.4 (EOL)